### PR TITLE
Fixes Empty Delimiter notices being raised when paths do not exist

### DIFF
--- a/File/Iterator.php
+++ b/File/Iterator.php
@@ -86,7 +86,7 @@ class File_Iterator extends FilterIterator
      */
     public function __construct(Iterator $iterator, array $suffixes = array(), array $prefixes = array(), array $exclude = array(), $basepath = NULL)
     {
-        $exclude = array_map('realpath', $exclude);
+        $exclude = array_filter(array_map('realpath', $exclude));
 
         if ($basepath !== NULL) {
             $basepath = realpath($basepath);


### PR DESCRIPTION
When calling `realpath` on the paths in `$exclude`, any non-existing path will be kept in `$exclude` as `FALSE`. When the Iterator then executes the `acceptPath()` method, any such values are converted to an empty string. This will result in an `E_NOTICE` being raised by `str_pos`. The proposed change is to `array_filter` the `$exclude` array after using `realpath` on it in the ctor.
