### PR TITLE
Notice fix and index replacement

### DIFF
--- a/File/Iterator/Facade.php
+++ b/File/Iterator/Facade.php
@@ -142,7 +142,10 @@ class File_Iterator_Facade
             }
 
             if (!$done) {
-                $common .= $_files[0][$j];
+                
+                if (isset($_files[$i])) {
+    				$common .= $_files[$i][$j];
+				}
 
                 if ($j > 0) {
                     $common .= DIRECTORY_SEPARATOR;


### PR DESCRIPTION
Line 145 tried to read $_files[0] all the time, it seems strange to force it to zero, so i pushed it to $i, please review.

Also added a check to avoid this notice:

PHP Notice:  Undefined offset: 0 in /usr/lib/php/pear/File/Iterator/Facade.php on line 146

PHP Stack trace:
PHP   1. {main}() /usr/bin/phpcpd:0
PHP   2. PHPCPD_TextUI_Command::main() /usr/bin/phpcpd:51
PHP   3. File_Iterator_Facade->getFilesAsArray() /usr/lib/php/pear/PHPCPD/TextUI/Command.php:209
PHP   4. File_Iterator_Facade->getCommonPath() /usr/lib/php/pear/File/Iterator/Facade.php:99
