### PR TITLE
Avoid get parent directory

### DIFF
--- a/File/Iterator/Factory.php
+++ b/File/Iterator/Factory.php
@@ -104,7 +104,7 @@ class File_Iterator_Factory
                 $iterator->append(
                   new File_Iterator(
                     new RecursiveIteratorIterator(
-                      new RecursiveDirectoryIterator($path)
+                      new RecursiveDirectoryIterator($path, RecursiveDirectoryIterator::SKIP_DOTS)
                     ),
                     $suffixes,
                     $prefixes,


### PR DESCRIPTION
I get parent directory in File_Iterator_Facade::getFilesAsArray() on linux machine.
It can be avoided in File_Iterator_Factory::getFileIterator() by passing  constant RecursiveDirectoryIterator::SKIP_DOTS  in RecursiveDirectoryIterator();
