### PR TITLE
Follow symlinks

### DIFF
--- a/File/Iterator/Factory.php
+++ b/File/Iterator/Factory.php
@@ -104,7 +104,7 @@ class File_Iterator_Factory
                 $iterator->append(
                   new File_Iterator(
                     new RecursiveIteratorIterator(
-                      new RecursiveDirectoryIterator($path)
+                      new RecursiveDirectoryIterator($path, RecursiveDirectoryIterator::FOLLOW_SYMLINKS)
                     ),
                     $suffixes,
                     $prefixes,


### PR DESCRIPTION
I am the developer of several [Drupal](http://drupal.org) modules and to make my life easier I created symlinks to those modules within a Drupal installation I use as a testbed. However, as symlinks are not followed, my modules' PHPUnit tests are not recognized by PHPUnit when running tests from the Drupal root. Supporting symlinks will allow me to run all PHPUnit tests in the installation together in one go.
