### PR TITLE
support for wildcards (glob) in exclude

### DIFF
--- a/File/Iterator/Factory.php
+++ b/File/Iterator/Factory.php
@@ -68,18 +68,8 @@ class File_Iterator_Factory
             $paths = array($paths);
         }
 
-        $_paths = array();
-
-        foreach ($paths as $path) {
-            if ($locals = glob($path, GLOB_ONLYDIR)) {
-                $_paths = array_merge($_paths, $locals);
-            } else {
-                $_paths[] = $path;
-            }
-        }
-
-        $paths = $_paths;
-        unset($_paths);
+        $paths   = $this->getPathsAfterResolvingWildcards($paths);
+        $exclude = $this->getPathsAfterResolvingWildcards($exclude);
 
         if (is_string($prefixes)) {
             if ($prefixes != '') {
@@ -116,5 +106,24 @@ class File_Iterator_Factory
         }
 
         return $iterator;
+    }
+
+    /**
+     * @param  array $paths
+     * @return array
+     */
+    protected function getPathsAfterResolvingWildcards(array $paths)
+    {
+        $_paths = array();
+
+        foreach ($paths as $path) {
+            if ($locals = glob($path, GLOB_ONLYDIR)) {
+                $_paths = array_merge($_paths, $locals);
+            } else {
+                $_paths[] = $path;
+            }
+        }
+
+        return $_paths;
     }
 }


### PR DESCRIPTION
Currently, only real paths are allowed. This would allow to exclude paths like `/home/project/plugin/*/integration-tests`.

**Example**

This would allow us to define testsuites as follows

```
   <testsuite name="SystemTests">
        <directory>./System</directory>
        <directory>../../plugins/*/tests</directory>
        <exclude>../../plugins/*/tests/Integration</exclude>
        <exclude>../../plugins/*/tests/Unit</exclude>
    </testsuite>
    <testsuite name="IntegrationTests">
        <directory>./Integration</directory>
        <directory>../../plugins/*/tests/Integration</directory>
    </testsuite>
    <testsuite name="UnitTests">
        <directory>./Unit</directory>
        <directory>../../plugins/*/tests/Unit</directory>
    </testsuite>
```

Basically, in `SystemTests` we want to run all tests that were not grouped into Unit or Integration tests as plugins might not follow guidelines to put them into a Unit or Integration directory and to stay backwards compatibility. We would maybe even create a new suite for uncategorized tests or something similar.

With the current behavior we would execute in `SystemTests` all tests of `UnitTests` and `IntegrationTests` as well but we want to exclude them. There can be many plugins which even very from installation to installation and it is therefore not possible to define fixed directories.