### PR TITLE
Set exclude var to "/" if its an empty string after removing the basepath

### DIFF
--- a/src/Iterator.php
+++ b/src/Iterator.php
@@ -59,6 +59,9 @@ class File_Iterator extends FilterIterator
         } else {
             foreach ($exclude as &$_exclude) {
                 $_exclude = str_replace($basepath, '', $_exclude);
+                if ($_exclude === '') {
+                    $_exclude = '/';
+                }
             }
         }
 


### PR DESCRIPTION
With following testsuites configuration, the php-file-iterator returned a PHP warning
To prevent this warning I suggest that if the $_exclude var ist empty after removing the basepath it should be set to '/'.

Testsuite configuration:

```
<testsuites>
    <testsuite name="some">
        <directory>../src/Acme/SomeBundle/Tests</directory>
    </testsuite>
    <testsuite name="other">
        <directory>../src/*/*Bundle/Tests</directory>
        <directory>../src/*/*/*Bundle/Tests</directory>
        <exclude>../src/Acme/SomeBundle/Tests</exclude>
    </testsuite>
</testsuites>
```

PHP-Warning:

```
PHP Warning:  strpos(): Empty needle in /some-dir/vendor/phpunit/php-file-iterator/src/Iterator.php on line 104
```
