### PR TITLE
Fix minor PHPDoc inconsistency

### DIFF
--- a/src/Iterator.php
+++ b/src/Iterator.php
@@ -131,7 +131,7 @@ class File_Iterator extends FilterIterator
 
     /**
      * @param  string $filename
-     * @param  array  $subString
+     * @param  array  $subStrings
      * @param  int    $type
      * @return bool
      * @since  Method available since Release 1.1.0


### PR DESCRIPTION
Parameter name in phpdoc differs from actual parameter name in method signature, which adds some noise without a reason.