### PR TITLE
Fix type of inner iterator of the Iterator object

### DIFF
--- a/src/Iterator.php
+++ b/src/Iterator.php
@@ -54,7 +54,7 @@ class Iterator extends \FilterIterator
             $basePath = null;
         } else {
             foreach ($exclude as &$_exclude) {
-                $_exclude = \str_replace($basepath, '', $_exclude);
+                $_exclude = \str_replace($basePath, '', $_exclude);
             }
         }
 

--- a/src/Iterator.php
+++ b/src/Iterator.php
@@ -36,13 +36,13 @@ class Iterator extends \FilterIterator
     private $basePath;
 
     /**
-     * @param Iterator $iterator
-     * @param array    $suffixes
-     * @param array    $prefixes
-     * @param array    $exclude
-     * @param string   $basePath
+     * @param \Iterator $iterator
+     * @param array     $suffixes
+     * @param array     $prefixes
+     * @param array     $exclude
+     * @param string    $basePath
      */
-    public function __construct(Iterator $iterator, array $suffixes = [], array $prefixes = [], array $exclude = [], $basePath = null)
+    public function __construct(\Iterator $iterator, array $suffixes = [], array $prefixes = [], array $exclude = [], $basePath = null)
     {
         $exclude = \array_filter(\array_map('realpath', $exclude));
 


### PR DESCRIPTION
There is bug, the first argument of the `SebastianBergmann\FileIterator\Iterator` constructor must be instance the `\Iterator`, what `FilterIterator` is expected.