### PR TITLE
Fix iteration files with usage directory or exclude uses glob

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -56,8 +56,7 @@ class Factory
                         ),
                         $suffixes,
                         $prefixes,
-                        $exclude,
-                        $path
+                        $exclude
                     )
                 );
             }

--- a/src/Iterator.php
+++ b/src/Iterator.php
@@ -31,37 +31,18 @@ class Iterator extends \FilterIterator
     private $exclude = [];
 
     /**
-     * @var string
-     */
-    private $basePath;
-
-    /**
      * @param \Iterator $iterator
      * @param array     $suffixes
      * @param array     $prefixes
      * @param array     $exclude
-     * @param string    $basePath
      */
-    public function __construct(\Iterator $iterator, array $suffixes = [], array $prefixes = [], array $exclude = [], $basePath = null)
+    public function __construct(\Iterator $iterator, array $suffixes = [], array $prefixes = [], array $exclude = [])
     {
         $exclude = \array_filter(\array_map('realpath', $exclude));
-
-        if ($basePath !== null) {
-            $basePath = \realpath($basePath);
-        }
-
-        if ($basePath === false) {
-            $basePath = null;
-        } else {
-            foreach ($exclude as &$_exclude) {
-                $_exclude = \str_replace($basePath, '', $_exclude);
-            }
-        }
 
         $this->prefixes = $prefixes;
         $this->suffixes = $suffixes;
         $this->exclude  = $exclude;
-        $this->basePath = $basePath;
 
         parent::__construct($iterator);
     }
@@ -71,10 +52,6 @@ class Iterator extends \FilterIterator
         $current  = $this->getInnerIterator()->current();
         $filename = $current->getFilename();
         $realPath = $current->getRealPath();
-
-        if ($this->basePath !== null) {
-            $realPath = \str_replace($this->basePath, '', $realPath);
-        }
 
         // Filter files in hidden directories.
         if (\preg_match('=/\.[^/]*/=', $realPath)) {

--- a/src/Iterator.php
+++ b/src/Iterator.php
@@ -54,7 +54,7 @@ class Iterator extends \FilterIterator
             $basePath = null;
         } else {
             foreach ($exclude as &$_exclude) {
-                $_exclude = \str_replace($basepath, '', $_exclude);
+                $_exclude = \str_replace($basePath, '', $_exclude);
             }
         }
 

--- a/src/Iterator.php
+++ b/src/Iterator.php
@@ -36,13 +36,13 @@ class Iterator extends \FilterIterator
     private $basePath;
 
     /**
-     * @param Iterator $iterator
-     * @param array    $suffixes
-     * @param array    $prefixes
-     * @param array    $exclude
-     * @param string   $basePath
+     * @param \Iterator $iterator
+     * @param array     $suffixes
+     * @param array     $prefixes
+     * @param array     $exclude
+     * @param string    $basePath
      */
-    public function __construct(Iterator $iterator, array $suffixes = [], array $prefixes = [], array $exclude = [], $basePath = null)
+    public function __construct(\Iterator $iterator, array $suffixes = [], array $prefixes = [], array $exclude = [], $basePath = null)
     {
         $exclude = \array_filter(\array_map('realpath', $exclude));
 


### PR DESCRIPTION
Blocked by https://github.com/sebastianbergmann/php-file-iterator/pull/39

Fixes https://github.com/sebastianbergmann/phpunit/issues/2815  and  https://github.com/sebastianbergmann/php-file-iterator/issues/30

# Problems

1) Path to exclude is less than basepath, `str_replace` the basepath fails
2) Path to exclude is equals to basepath, `strpos` fails

# Test

Unfortunately package does not have unit tests, there is test files:

~~~
#!/usr/bin/env php
<?php
require_once 'vendor/autoload.php';

$factory = new \SebastianBergmann\FileIterator\Factory();
$iterator = $factory->getFileIterator('local/*/test', '', '', ['local/two', 'local/three/*']);
$files = array_keys(iterator_to_array($iterator));

assert(in_array('/home/local/one/test/OneTest.php', $files) === true);
assert(in_array('/home/local/two/test/TwoTest.php', $files) === false);
assert(in_array('/home/local/three/test/ThreeTest.php', $files) === false);
~~~

# Proposal

Remove the `basePath` from iterator at all, compare the real path from file iterator and real path in excludes. 