### PR TITLE
Skip dots items on iterate files

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -52,7 +52,10 @@ class Factory
                 $iterator->append(
                     new Iterator(
                         new \RecursiveIteratorIterator(
-                            new \RecursiveDirectoryIterator($path, \RecursiveDirectoryIterator::FOLLOW_SYMLINKS)
+                            new \RecursiveDirectoryIterator(
+                                $path,
+                                \RecursiveDirectoryIterator::FOLLOW_SYMLINKS | \RecursiveDirectoryIterator::SKIP_DOTS
+                            )
                         ),
                         $suffixes,
                         $prefixes,


### PR DESCRIPTION
# Problems

Iterator returns extra items.

# Test

There is test file

~~~php
#!/usr/bin/env php
<?php
require_once 'vendor/autoload.php';

$facade = new \SebastianBergmann\FileIterator\Facade();
$files = $facade->getFilesAsArray('local/*/test', '', '', ['local/two', 'local/three/*']);

var_dump($files);
~~~

Result before:

~~~
/home/php-file-iterator/local.php:13:
array(4) {
  [0] =>
  string(63) "/home/php-file-iterator/local/one"
  [1] =>
  string(68) "/home/php-file-iterator/local/one/test"
  [2] =>
  string(80) "/home/php-file-iterator/local/one/test/OneTest.php"
  [3] =>
  string(65) "/home/php-file-iterator/local/three"
~~~

Result after:

~~~
/home/php-file-iterator/local.php:13:
array(3) {
  [0] =>
  string(80) "/home/php-file-iterator/local/one/test/OneTest.php"
~~~