### PR TITLE
ignore exclude wildcard directories that do not resolve to paths

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -73,7 +73,10 @@ class Factory
             if ($locals = \glob($path, GLOB_ONLYDIR)) {
                 $_paths = \array_merge($_paths, \array_map('\realpath', $locals));
             } else {
-                $_paths[] = \realpath($path);
+                $realpath = \realpath($path);
+                if (false !== $realpath) {
+                    $_paths[] = $realpath;
+                }
             }
         }
 


### PR DESCRIPTION
This is to handle a case where, for example, an exclude directory is specified with a wildcard, but no directories are actually matched by the `\glob()` call. At present, this causes `\realpath($path)` to return false. Such a value should be filtered out of the returned paths.

If this PR is insufficient either as a code change or in the description here, let me know and I can rectify.