### PR TITLE
Fix filtering hidden files only inside the base path

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -51,8 +51,9 @@ class Factory
             if (\is_dir($path)) {
                 $iterator->append(
                     new Iterator(
+                        $path,
                         new \RecursiveIteratorIterator(
-                            new \RecursiveDirectoryIterator($path, \RecursiveDirectoryIterator::FOLLOW_SYMLINKS)
+                            new \RecursiveDirectoryIterator($path, \RecursiveDirectoryIterator::FOLLOW_SYMLINKS | \RecursiveDirectoryIterator::SKIP_DOTS)
                         ),
                         $suffixes,
                         $prefixes,


### PR DESCRIPTION
Fix the regression #46 introduced by #40

# Test
~~~php
#!/usr/bin/env php
<?php
require_once 'vendor/autoload.php';

$facade = new \SebastianBergmann\FileIterator\Facade();
$files = $facade->getFilesAsArray('.local/*/test', '', '', ['.local/two', '.local/three/*']);

assert(in_array('/Users/mc/Documents/p/forks/phpunit/php-file-iterator/.local/one/test/OneTest.php', $files) === true);
assert(in_array('/Users/mc/Documents/p/forks/phpunit/php-file-iterator/.local/two/test/TwoTest.php', $files) === false);
assert(in_array('/Users/mc/Documents/p/forks/phpunit/php-file-iterator/.local/three/test/ThreeTest.php', $files) === false);

var_dump($files);
~~~
with files
~~~shell
$ find .local
.local
.local/one
.local/one/OneOneTest.php
.local/one/test
.local/one/test/.hidden
.local/one/test/.hidden/OneTest.php
.local/one/test/OneTest.php
.local/three
.local/three/test
.local/three/test/ThreeTest.php
.local/two
.local/two/test
.local/two/test/TwoTest.php
~~~
