### PR TITLE
Fix: Add vendor directory and composer.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.idea
+/vendor/
 /.php_cs
 /.php_cs.cache
-
+/composer.lock


### PR DESCRIPTION
This PR

* [x] adds the `vendor` directory and `composer.lock` to `.gitignore`