### PR TITLE
Fix: Include tests directory when running php-cs-fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -163,5 +163,6 @@ return PhpCsFixer\Config::create()
         PhpCsFixer\Finder::create()
         ->files()
         ->in(__DIR__ . '/src')
+        ->in(__DIR__ . '/tests')
         ->notName('*.phpt')
     );

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -1,9 +1,14 @@
 <?php
-
+/*
+ * This file is part of php-file-iterator.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 namespace SebastianBergmann\FileIterator;
 
-use org\bovigo\vfs\vfsStream;
-use org\bovigo\vfs\vfsStreamDirectory;
 use PHPUnit\Framework\TestCase;
 
 class FactoryTest extends TestCase
@@ -18,25 +23,25 @@ class FactoryTest extends TestCase
      */
     private $factory;
 
-    public function setUp()
+    public function setUp(): void
     {
-        $this->root = __DIR__;
+        $this->root    = __DIR__;
         $this->factory = new Factory;
     }
 
-    public function testFindFilesInTestDirectory()
+    public function testFindFilesInTestDirectory(): void
     {
         $iterator = $this->factory->getFileIterator($this->root, 'Test.php');
-        $files = \iterator_to_array($iterator);
+        $files    = \iterator_to_array($iterator);
 
-        $this->assertGreaterThanOrEqual(1, count($files));
+        $this->assertGreaterThanOrEqual(1, \count($files));
     }
 
-    public function testFindFilesWithExcludedNonExistingSubdirectory()
+    public function testFindFilesWithExcludedNonExistingSubdirectory(): void
     {
         $iterator = $this->factory->getFileIterator($this->root, 'Test.php', '', [$this->root . '/nonExistingDir']);
-        $files = \iterator_to_array($iterator);
+        $files    = \iterator_to_array($iterator);
 
-        $this->assertGreaterThanOrEqual(1, count($files));
+        $this->assertGreaterThanOrEqual(1, \count($files));
     }
 }


### PR DESCRIPTION
This PR

* [x] adjusts the configuration for `php-cs-fixer` to include the `tests` directory
* [x] runs `php-cs-fixer`

Follows #50.