### PR TITLE
Fix: Reduce visibility

### DIFF
--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -23,7 +23,7 @@ class FactoryTest extends TestCase
      */
     private $factory;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->root    = __DIR__;
         $this->factory = new Factory;


### PR DESCRIPTION
This PR

* [x] reduces the visibility of `setUp()` from `public` to `protected`

💁‍♂️ I ran

```
$ php-cs-fixer fix --rules=php_unit_set_up_tear_down_visibility --allow-risky yes
```