### PR TITLE
Fix: Add missing covers annotation

### DIFF
--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -11,6 +11,9 @@ namespace SebastianBergmann\FileIterator;
 
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers \SebastianBergmann\FileIterator\Factory
+ */
 class FactoryTest extends TestCase
 {
     /**


### PR DESCRIPTION
This PR

* [x] adds a missing class-level `@covers` annotation