### PR TITLE
Fix: Configure `COMPOSER_ROOT_VERSION`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ name: "CI"
 permissions:
   contents: read
 
+env:
+  COMPOSER_ROOT_VERSION: "4.0-dev"
+
 jobs:
   coding-guidelines:
     name: Coding Guidelines


### PR DESCRIPTION
This pull request

- [x] configures [`COMPOSER_ROOT_VERSION`](https://getcomposer.org/doc/03-cli.md#composer-root-version)