### PR TITLE
Fix: Ignore unresolvable symbolic link

### DIFF
--- a/src/ExcludeIterator.php
+++ b/src/ExcludeIterator.php
@@ -10,6 +10,7 @@
 namespace SebastianBergmann\FileIterator;
 
 use function assert;
+use function is_string;
 use function str_starts_with;
 use RecursiveDirectoryIterator;
 use RecursiveFilterIterator;
@@ -42,6 +43,10 @@ final class ExcludeIterator extends RecursiveFilterIterator
         assert($current instanceof SplFileInfo);
 
         $path = $current->getRealPath();
+
+        if (!is_string($path)) {
+            return false;
+        }
 
         foreach ($this->exclude as $exclude) {
             if (str_starts_with($path, $exclude)) {

--- a/tests/unit/FacadeTest.php
+++ b/tests/unit/FacadeTest.php
@@ -10,6 +10,8 @@
 namespace SebastianBergmann\FileIterator;
 
 use function realpath;
+use function symlink;
+use function unlink;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Small;
@@ -24,7 +26,7 @@ final class FacadeTest extends TestCase
 {
     public static function provider(): array
     {
-        $fixtureDirectoryRealpath = realpath(__DIR__ . '/../fixture');
+        $fixtureDirectoryRealpath = self::fixtureDirectoryRealpath();
 
         return [
             'filter prefix: no, filter suffix: no, excludes: none' => [
@@ -119,6 +121,21 @@ final class FacadeTest extends TestCase
         ];
     }
 
+    protected function setUp(): void
+    {
+        $fixtureDirectoryRealpath = self::fixtureDirectoryRealpath();
+
+        symlink(
+            $fixtureDirectoryRealpath . '/a/DoesNotExist.php',
+            $fixtureDirectoryRealpath . '/a/DoesNotExist.php',
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        unlink(self::fixtureDirectoryRealpath() . '/a/DoesNotExist.php');
+    }
+
     #[DataProvider('provider')]
     public function testSomething(array $expected, array|string $paths, array|string $suffixes, array|string $prefixes, array $exclude): void
     {
@@ -126,5 +143,10 @@ final class FacadeTest extends TestCase
             $expected,
             (new Facade)->getFilesAsArray($paths, $suffixes, $prefixes, $exclude)
         );
+    }
+
+    private static function fixtureDirectoryRealpath(): string|false
+    {
+        return realpath(__DIR__ . '/../fixture');
     }
 }


### PR DESCRIPTION
This pull request

- [x] creates a self-referencing symbolic link
- [x] ignores files where the real path can not be resolved

Fixes https://github.com/sebastianbergmann/phpunit/issues/5352.