### PR TITLE
Do not abort a traversal because of a directory that cannot be opened

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -28,6 +28,7 @@ use AppendIterator;
 use FilesystemIterator;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
+use UnexpectedValueException;
 
 /**
  * @internal This class is not covered by the backward compatibility promise for phpunit/php-file-iterator
@@ -70,24 +71,55 @@ final class Factory
         $iterator = new AppendIterator;
 
         foreach ($paths as $path) {
-            if (is_dir($path)) {
-                $iterator->append(
-                    new Iterator(
-                        $path,
-                        new RecursiveIteratorIterator(
-                            new ExcludeIterator(
-                                new RecursiveDirectoryIterator($path, FilesystemIterator::FOLLOW_SYMLINKS | FilesystemIterator::SKIP_DOTS),
-                                $exclude,
-                            ),
-                        ),
-                        $suffixes,
-                        $prefixes,
-                    ),
-                );
+            if (!is_dir($path)) {
+                continue;
             }
+
+            $directoryIterator = $this->directoryIterator($path);
+
+            if ($directoryIterator === null) {
+                continue;
+            }
+
+            $iterator->append(
+                new Iterator(
+                    $path,
+                    new RecursiveIteratorIterator(
+                        new ExcludeIterator(
+                            $directoryIterator,
+                            $exclude,
+                        ),
+                        RecursiveIteratorIterator::LEAVES_ONLY,
+                        RecursiveIteratorIterator::CATCH_GET_CHILD,
+                    ),
+                    $suffixes,
+                    $prefixes,
+                ),
+            );
         }
 
         return $iterator;
+    }
+
+    /**
+     * A directory that cannot be opened is skipped instead of aborting the
+     * traversal it is part of.
+     *
+     * This happens when the directory cannot be read by the current user, and
+     * it happens when the directory is removed by another process after it was
+     * read from its parent directory and before it is opened here.
+     *
+     * RecursiveIteratorIterator::CATCH_GET_CHILD does this for the directories
+     * that are descended into; this method does it for the root of a traversal,
+     * which is opened here and not by RecursiveIteratorIterator.
+     */
+    private function directoryIterator(string $path): ?RecursiveDirectoryIterator
+    {
+        try {
+            return new RecursiveDirectoryIterator($path, FilesystemIterator::FOLLOW_SYMLINKS | FilesystemIterator::SKIP_DOTS);
+        } catch (UnexpectedValueException) {
+            return null;
+        }
     }
 
     /**

--- a/tests/unit/UnopenableDirectoryTest.php
+++ b/tests/unit/UnopenableDirectoryTest.php
@@ -1,0 +1,105 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of phpunit/php-file-iterator.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace SebastianBergmann\FileIterator;
+
+use const DIRECTORY_SEPARATOR;
+use function chmod;
+use function file_put_contents;
+use function is_readable;
+use function mkdir;
+use function realpath;
+use function rmdir;
+use function sys_get_temp_dir;
+use function tempnam;
+use function unlink;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Small;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ExcludeIterator::class)]
+#[CoversClass(Facade::class)]
+#[CoversClass(Factory::class)]
+#[CoversClass(Iterator::class)]
+#[Small]
+final class UnopenableDirectoryTest extends TestCase
+{
+    private ?string $directory = null;
+
+    protected function tearDown(): void
+    {
+        if ($this->directory === null) {
+            return;
+        }
+
+        chmod($this->directory . '/unopenable', 0o755);
+
+        unlink($this->directory . '/unopenable/Unreachable.php');
+        unlink($this->directory . '/Reachable.php');
+
+        rmdir($this->directory . '/unopenable');
+        rmdir($this->directory);
+
+        $this->directory = null;
+    }
+
+    public function testDirectoryThatCannotBeOpenedDoesNotAbortTheTraversal(): void
+    {
+        $directory = $this->directoryWithUnopenableSubdirectory();
+
+        $this->assertSame(
+            [$directory . '/Reachable.php'],
+            (new Facade)->getFilesAsArray($directory, '.php'),
+        );
+    }
+
+    public function testDirectoryThatCannotBeOpenedIsSkippedWhenItIsTheRootOfTheTraversal(): void
+    {
+        $directory = $this->directoryWithUnopenableSubdirectory();
+
+        $this->assertSame(
+            [],
+            (new Facade)->getFilesAsArray($directory . '/unopenable', '.php'),
+        );
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    private function directoryWithUnopenableSubdirectory(): string
+    {
+        if (DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestSkipped('This test does not work on Windows');
+        }
+
+        $path = tempnam(sys_get_temp_dir(), 'php-file-iterator');
+
+        unlink($path);
+        mkdir($path . '/unopenable', 0o755, true);
+
+        file_put_contents($path . '/Reachable.php', '<?php');
+        file_put_contents($path . '/unopenable/Unreachable.php', '<?php');
+
+        chmod($path . '/unopenable', 0o000);
+
+        $this->directory = $path;
+
+        if (is_readable($path . '/unopenable')) {
+            $this->markTestSkipped('This test requires a directory that cannot be read by the current user');
+        }
+
+        $realPath = realpath($path);
+
+        if ($realPath === false) {
+            $this->fail('The path of the temporary directory could not be resolved');
+        }
+
+        return $realPath;
+    }
+}


### PR DESCRIPTION
## The bug

`Factory::getFileIterator()` builds a `RecursiveIteratorIterator` with default flags. During descent, `RecursiveIteratorIterator` calls `ExcludeIterator::getChildren()`, which constructs a new `RecursiveDirectoryIterator` for the subdirectory. When `opendir()` fails, that constructor throws `UnexpectedValueException`, and without `RecursiveIteratorIterator::CATCH_GET_CHILD` the exception escapes the entire traversal.

A single directory that cannot be opened therefore aborts the whole walk:

```
UnexpectedValueException: RecursiveDirectoryIterator::__construct(…/build/unreadable):
Failed to open directory: Permission denied
```

There are two ways to reach this:

* The directory cannot be read by the user running the traversal.
* The directory is removed by another process between the moment it is read from its parent and the moment it is opened. This is not hypothetical: in a monorepo where several `composer update` runs work in parallel below a directory that is being walked, Composer creates and removes a temporary extraction directory, and the walk enters it in between.

The same failure exists for the root of a traversal. `getFileIterator()` checks `is_dir($path)` and then constructs the `RecursiveDirectoryIterator` itself, so `CATCH_GET_CHILD` does not apply there — an unreadable configured directory, or one that disappears between the `is_dir()` check and the constructor, throws just as well.

This affects every consumer of this component. In PHPUnit it aborts the run before the first test with "An error occurred inside PHPUnit", reported in [phpunit/phpunit#6915](https://github.com/sebastianbergmann/phpunit/pull/6915).

## The change

* `RecursiveIteratorIterator` is now constructed with `RecursiveIteratorIterator::CATCH_GET_CHILD`. A directory that cannot be opened during descent is skipped, and the traversal continues.
* The construction of the root `RecursiveDirectoryIterator` is guarded so that a root directory which cannot be opened is skipped as well.

Skipping is what this component already does when a configured path is not a directory at all: `getFileIterator()` passes over it without complaint. "A directory that cannot be opened contributes no files" is the same contract, applied to a directory that exists but cannot be read.

The result of a traversal that contains no unopenable directory does not change.

## Tests

`UnopenableDirectoryTest` covers both cases:

* `testDirectoryThatCannotBeOpenedDoesNotAbortTheTraversal` — an unreadable directory below the traversed one; the files beside it are still found.
* `testDirectoryThatCannotBeOpenedIsSkippedWhenItIsTheRootOfTheTraversal` — the traversed directory itself is unreadable; the result is empty.

Both fail on `6.0` with the exception above and pass with this change.

The fixture is created below `sys_get_temp_dir()` rather than committed, because Git does not preserve directory permissions. The test skips on Windows, and it skips when a mode `0000` directory is still readable by the current user, which is the case when the suite runs as `root`.

## Checks

* `./vendor/bin/phpunit`: OK, 10 tests, 10 assertions.
* `./tools/php-cs-fixer fix`: 0 of 23 files fixed.
* `./tools/phpstan analyse`: no errors.

Verified against PHPUnit as well: with this branch in `vendor/`, the three scenarios below all pass with an unmodified `SourceMapper`, and PHPUnit's own unit suite stays green (4053 tests, 12124 assertions).

| scenario | `6.0` | this branch |
| --- | --- | --- |
| unreadable directory below an excluded directory | crash | ok |
| unreadable directory below an included directory that is not excluded | crash | ok |
| unreadable directory below an excluded `vendor`, with a `vendor-bin` sibling | crash | ok |

## Note

This targets `6.0`, which is what PHPUnit 12.5 requires, and merges up to `main`.
