### PR TITLE
Do not exclude paths that only share a prefix with an excluded directory

### DIFF
--- a/src/ExcludeIterator.php
+++ b/src/ExcludeIterator.php
@@ -9,7 +9,10 @@
  */
 namespace SebastianBergmann\FileIterator;
 
+use const DIRECTORY_SEPARATOR;
+use function array_map;
 use function assert;
+use function rtrim;
 use function str_starts_with;
 use RecursiveDirectoryIterator;
 use RecursiveFilterIterator;
@@ -34,7 +37,10 @@ final class ExcludeIterator extends RecursiveFilterIterator
     {
         parent::__construct($iterator);
 
-        $this->exclude = $exclude;
+        $this->exclude = array_map(
+            static fn (string $path): string => rtrim($path, '/' . DIRECTORY_SEPARATOR),
+            $exclude,
+        );
     }
 
     public function accept(): bool
@@ -50,7 +56,7 @@ final class ExcludeIterator extends RecursiveFilterIterator
         }
 
         foreach ($this->exclude as $exclude) {
-            if (str_starts_with($path, $exclude)) {
+            if ($path === $exclude || str_starts_with($path, $exclude . DIRECTORY_SEPARATOR)) {
                 return false;
             }
         }

--- a/tests/unit/FacadeTest.php
+++ b/tests/unit/FacadeTest.php
@@ -77,6 +77,26 @@ final class FacadeTest extends TestCase
                 ],
             ],
 
+            'excludes directory does not exclude files with matching prefix' => [
+                [
+                    $fixtureDirectoryRealpath . '/aFile.php',
+                    $fixtureDirectoryRealpath . '/b/PrefixSuffix.php',
+                    $fixtureDirectoryRealpath . '/b/e/PrefixSuffix.php',
+                    $fixtureDirectoryRealpath . '/b/e/g/PrefixSuffix.php',
+                    $fixtureDirectoryRealpath . '/b/e/g/i/PrefixSuffix.php',
+                    $fixtureDirectoryRealpath . '/b/e/i/PrefixSuffix.php',
+                    $fixtureDirectoryRealpath . '/b/f/PrefixSuffix.php',
+                    $fixtureDirectoryRealpath . '/b/f/h/PrefixSuffix.php',
+                    $fixtureDirectoryRealpath . '/b/f/h/i/PrefixSuffix.php',
+                ],
+                __DIR__ . '/../fixture',
+                '',
+                '',
+                [
+                    $fixtureDirectoryRealpath . '/a',
+                ],
+            ],
+
             'excludes directory with trailing slash does not exclude files with matching prefix (issue #84)' => [
                 [
                     $fixtureDirectoryRealpath . '/aFile.php',


### PR DESCRIPTION
## Please read this first

This pull request was written by an LLM-based coding assistant working under my direction, so it falls under the rule in CONTRIBUTING.md about AI-generated pull requests. I am telling you up front rather than letting you find out: close it without any explanation if that is what you prefer, take it as it is, or take it as a starting point for your own patch. No hard feelings either way. It follows the `ExcludeIterator` boundary bug you described in sebastianbergmann/phpunit#6915, and it seemed more useful to send it than to keep it.

## The bug

`ExcludeIterator::accept()` rejects a path when it merely starts with an excluded path:

```php
if (str_starts_with($path, $exclude)) {
    return false;
}
```

Excluding `tests` therefore also excludes `tests-integration` and `testsBootstrap.php`. `Factory::resolveWildcards()` keeps a trailing directory separator since #84, so `tests/` is a way to opt out of that, but the form without the separator is the one callers write, and `PHPUnit\TextUI\Configuration\Xml\TestSuiteMapper` passes exactly that.

### Steps to reproduce

```php
$base = sys_get_temp_dir() . '/pfi';

mkdir($base . '/tests', 0o777, true);
mkdir($base . '/tests-integration', 0o777, true);
file_put_contents($base . '/tests/Excluded.php', '<?php');
file_put_contents($base . '/tests-integration/Included.php', '<?php');
file_put_contents($base . '/Keep.php', '<?php');

print_r((new Facade)->getFilesAsArray($base, ['.php'], '', [$base . '/tests']));
```

Before:

```
Keep.php
```

After:

```
Keep.php
tests-integration/Included.php
```

`$base . '/tests/'` already returns the second result today, and keeps doing so.

## The change

`accept()` now compares on the directory boundary, `$path === $exclude || str_starts_with($path, $exclude . DIRECTORY_SEPARATOR)`. The first half keeps the excluded directory itself out of the traversal, so the subtree is still pruned rather than walked and filtered file by file.

The constructor strips a trailing directory separator from every excluded path, so `tests` and `tests/` mean the same thing. That makes the trailing separator that `Factory::resolveWildcards()` preserves for #84 unnecessary, but I left that code alone: it is not wrong, and removing it belongs in its own change.

## Tests

`'excludes directory does not exclude files with matching prefix'` uses the existing fixture, where `aFile.php` sits next to the directory `a`. It fails on `6.0` and passes with this change. The case for `#84` right below it covers the trailing-slash form and passes in both states.

The sibling in the fixture is a file. A sibling directory takes the same path through `accept()`, and the reproducer above covers it, but adding one to the fixture would mean editing every expectation in the provider, so I did not.

## Checks

* `./vendor/bin/phpunit`: OK, 9 tests, 9 assertions. Reverting `src/ExcludeIterator.php` alone makes the new case fail with the expected diff.
* `./tools/php-cs-fixer fix`: 0 of 22 files fixed.
* `./tools/phpstan analyse`: no errors.
